### PR TITLE
Add CSS fix for flipped deck text

### DIFF
--- a/style.css
+++ b/style.css
@@ -174,6 +174,12 @@ button:hover {
 .deck-theme-orange { background: linear-gradient(135deg, #f6d365, #fda085); }
 .deck-theme-orange::before, .deck-theme-orange::after { background: linear-gradient(135deg, #f6d365, #fda085); }
 
+/* --- CORRECCIÓN PARA OCULTAR TEXTO DEL REVERSO --- */
+#card-area.is-flipped #card-deck {
+    color: transparent;
+    text-shadow: none;
+}
+
 
 /* ---------------------------------- */
 /* 5. CARD DISPLAY STYLES (FACE-UP)   */


### PR DESCRIPTION
## Summary
- hide card deck text when the deck is flipped

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a95ac3b048327909fb1b1b09eea68