### PR TITLE
Enable vertical cards with rounded white border

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
         <div id="timer-display">--</div>
 
         <div id="card-area">
-            <div id="card-deck" data-lang-key="clickToStart">
+            <div id="card-deck" class="card" data-lang-key="clickToStart">
                 Click to Start
             </div>
 
-            <div id="card-display" class="hidden">
+            <div id="card-display" class="card hidden">
                 <div id="emoji"></div>
                 <div id="word"></div>
                 <div id="level"></div>

--- a/style.css
+++ b/style.css
@@ -107,6 +107,7 @@ button:hover {
     transform-style: preserve-3d;
     backface-visibility: hidden; /* Hides the back of the element when flipped */
     border-radius: var(--border-radius);
+    border: 4px solid #fff;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -203,8 +204,8 @@ button:hover {
     font-size: 4rem;
     line-height: 1.1;
     text-transform: uppercase;
-    /* writing-mode: vertical-rl; */
-    /* text-orientation: upright; */
+    writing-mode: vertical-rl;
+    text-orientation: upright;
 }
 
 #card-display #level {
@@ -220,7 +221,6 @@ button:hover {
 /* Style 1: Comic Book Pop! */
 .card-style-1 {
     background-color: #ffd166;
-    border: 5px solid var(--color-dark);
     color: var(--color-dark);
     box-shadow: 10px 10px 0px #06d6a0;
     animation: popIn 0.5s cubic-bezier(0.68, -0.55, 0.27, 1.55);
@@ -232,7 +232,6 @@ button:hover {
 .card-style-2 {
     background-color: #1D1029;
     color: #fff;
-    border: 2px solid #f92a82;
     animation: fadeIn 0.5s;
 }
 .card-style-2 #word {
@@ -246,7 +245,6 @@ button:hover {
 .card-style-3 {
     background: rgba(135, 207, 235, 0.8);
     backdrop-filter: blur(5px);
-    border: 2px solid rgba(255, 255, 255, 0.5);
     color: var(--color-dark);
     animation: jiggle 0.6s;
 }
@@ -257,7 +255,6 @@ button:hover {
 .card-style-4 {
     background: linear-gradient(45deg, #ff9a9e 0%, #fad0c4 99%, #fad0c4 100%);
     color: var(--color-light);
-    border: 4px dashed var(--color-light);
     animation: fadeIn 0.5s;
 }
 .card-style-4 #word { text-shadow: 3px 3px 2px rgba(0,0,0,0.2); }
@@ -266,7 +263,6 @@ button:hover {
 /* Style 5: Hand-Drawn Sketch */
 .card-style-5 {
     background-color: #faf8f0;
-    border: 3px solid var(--color-dark);
     border-radius: 15px 255px 20px 225px / 225px 20px 255px 15px; /* Quirky border */
     color: #444;
     animation: fadeIn 0.5s;
@@ -288,7 +284,6 @@ button:hover {
 /* Style 7: Minimalist Invert */
 .card-style-7 {
     background-color: var(--color-dark);
-    border: 1px solid #eee;
     color: var(--color-light);
     animation: fadeIn 0.5s;
 }


### PR DESCRIPTION
## Summary
- style game cards as `.card` elements with white border and rounded corners
- show the flipped word vertically
- adjust HTML to apply the new card class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a9758ce808327856feac210d36552