### PR TITLE
Fix overlap layout for card deck

### DIFF
--- a/style.css
+++ b/style.css
@@ -97,6 +97,7 @@ button:hover {
     width: var(--card-width);
     height: var(--card-height);
     perspective: 1500px; /* Essential for the 3D flip effect */
+    margin-bottom: -80px; /* Pull buttons up to overlap */
 }
 
 .card {


### PR DESCRIPTION
## Summary
- ensure card deck and action buttons overlap by adjusting negative margin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a9c7613088327b6fbd8f732226054