### PR TITLE
Add round timer and scoring UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
     </header>
 
     <main id="game-container">
+        <div id="score-display" class="hidden">
+            <span id="score-value">0</span>
+        </div>
+
         <div id="timer-display">--</div>
 
         <div id="card-area">
@@ -34,7 +38,7 @@
         </div>
 
         <div id="controls">
-            <label for="time-input" data-lang-key="timeLabel">Time per card (s):</label>
+            <label for="time-input" data-lang-key="timeLabel">Duración de la ronda (s):</label>
             <input type="number" id="time-input" value="90" min="10">
         </div>
     </main>

--- a/script.js
+++ b/script.js
@@ -6,24 +6,26 @@ let timeLeft;
 let gameInProgress = false;
 let currentLanguage = 'en';
 let timeSetting = 90;
+let score = 0; // <-- AÑADIR ESTA LÍNEA
 
 // Translation Dictionary
 const translations = {
     en: {
         newGame: 'New Game',
         clickToStart: 'Click Deck to Start',
-        timeLabel: 'Time per card (s):'
+        timeLabel: 'Round duration (s):' // <-- ACTUALIZAR TEXTO
     },
     es: {
         newGame: 'Nueva Partida',
         clickToStart: 'Clica para Empezar',
-        timeLabel: 'Tiempo por tarjeta (s):'
+        timeLabel: 'Duración de la ronda (s):' // <-- ACTUALIZAR TEXTO
     }
 };
 
 // DOM Elements
 let newGameBtn, langToggleBtn, cardDeck, cardDisplay, emojiEl, wordEl, levelEl, timerDisplay, timeInput;
 let actionButtons, passBtn, correctBtn;
+let scoreDisplay, scoreValue, gameContainer; // <-- AÑADIR ESTA LÍNEA
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -41,6 +43,9 @@ function init() {
     actionButtons = document.getElementById('action-buttons');
     passBtn = document.getElementById('pass-btn');
     correctBtn = document.getElementById('correct-btn');
+    scoreDisplay = document.getElementById('score-display'); // <-- AÑADIR ESTA LÍNEA
+    scoreValue = document.getElementById('score-value'); // <-- AÑADIR ESTA LÍNEA
+    gameContainer = document.getElementById('game-container'); // <-- AÑADIR ESTA LÍNEA
 
     fetchWords();
 
@@ -51,7 +56,21 @@ function init() {
     langToggleBtn.addEventListener('click', toggleLanguage);
     timeInput.addEventListener('change', updateTimeSetting);
     passBtn.addEventListener('click', drawNextCard);
-    correctBtn.addEventListener('click', drawNextCard);
+    correctBtn.addEventListener('click', handleCorrect); // <-- CAMBIAR A handleCorrect
+}
+
+// Justo después de la función init(), añade esta nueva función:
+function handleCorrect() {
+    score++;
+    scoreValue.textContent = score;
+    scoreDisplay.classList.add('score-pulse');
+
+    // Eliminar la clase de animación para que se pueda volver a activar
+    setTimeout(() => {
+        scoreDisplay.classList.remove('score-pulse');
+    }, 400);
+
+    drawNextCard();
 }
 
 function fetchWords() {
@@ -67,6 +86,10 @@ function fetchWords() {
 function startGame() {
     clearInterval(timer);
     gameInProgress = true;
+    score = 0; // <-- Reiniciar puntuación
+    scoreValue.textContent = score; // <-- Actualizar display
+    gameContainer.classList.add('game-active'); // <-- Mostrar marcador
+
     currentDeck = [...allWords];
     // Fisher-Yates shuffle
     for (let i = currentDeck.length - 1; i > 0; i--) {
@@ -84,6 +107,17 @@ function startGame() {
     cardDisplay.classList.remove('hidden');
     actionButtons.classList.remove('hidden');
     drawNextCard();
+
+    // --- NUEVA LÓGICA DEL TEMPORIZADOR DE RONDA ---
+    timeLeft = timeSetting;
+    timerDisplay.textContent = timeLeft;
+    timer = setInterval(() => {
+        timeLeft--;
+        timerDisplay.textContent = timeLeft;
+        if (timeLeft <= 0) {
+            endGame(); // El juego termina cuando el tiempo se agota
+        }
+    }, 1000);
 }
 
 function drawNextCard() {
@@ -103,22 +137,9 @@ function drawNextCard() {
     emojiEl.textContent = card.emoji;
     wordEl.textContent = card.word;
     levelEl.textContent = card.level;
-    startTimer();
 }
 
-function startTimer() {
-    clearInterval(timer);
-    timeLeft = timeSetting;
-    timerDisplay.textContent = timeLeft;
-    timer = setInterval(() => {
-        timeLeft--;
-        timerDisplay.textContent = timeLeft;
-        if (timeLeft <= 0) {
-            clearInterval(timer);
-            drawNextCard();
-        }
-    }, 1000);
-}
+
 
 function updateTimeSetting() {
     const val = parseInt(timeInput.value, 10);
@@ -143,4 +164,5 @@ function endGame() {
     cardArea.classList.remove('is-flipped');
     actionButtons.classList.add('hidden');
     timerDisplay.textContent = '--';
+    gameContainer.classList.remove('game-active'); // <-- Ocultar marcador
 }

--- a/style.css
+++ b/style.css
@@ -391,3 +391,42 @@ button:hover {
     50% { background-position: 100% 50%; }
     100% { background-position: 0% 50%; }
 }
+
+/* Estilo para el contenedor de puntos */
+#score-display {
+    font-family: var(--font-primary);
+    font-size: 2.5rem;
+    color: var(--color-light);
+    background: linear-gradient(135deg, #89f7fe, #66a6ff);
+    padding: 10px 30px;
+    border-radius: 50px;
+    border: 4px solid var(--color-light);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.15), inset 0 -4px 0 rgba(0,0,0,0.2);
+    margin-bottom: 10px;
+    text-shadow: 2px 2px 3px rgba(0,0,0,0.25);
+    transition: transform 0.2s ease;
+}
+
+#score-display.hidden {
+    display: none;
+}
+
+/* Clase para activar la animación de pulso */
+.score-pulse {
+    animation: scoreUpdate 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+/* Animación Keyframe para el pulso */
+@keyframes scoreUpdate {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.25) rotate(-5deg); }
+    100% { transform: scale(1); }
+}
+
+/* --- También añade esta línea para que el marcador no aparezca hasta que empiece el juego --- */
+#game-container > #score-display {
+    display: none; /* Oculto por defecto */
+}
+#game-container.game-active > #score-display {
+    display: block; /* Visible cuando el juego está activo */
+}


### PR DESCRIPTION
## Summary
- add animated score display to the page
- style new score display with pulse animation
- update language strings to mention round duration
- implement round timer and scoring logic in JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a9d9da6a08327ae88ae4f5683bf4d