### PR TITLE
Improve layout and word handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <button id="pass-btn" data-lang-key="pass">Pasar</button>
             <button id="correct-btn" data-lang-key="correct">¡Correcto!</button>
         </div>
+        <hr id="divider">
 
         <div id="controls">
             <label for="time-input" data-lang-key="timeLabel">Duración de la ronda (s):</label>

--- a/script.js
+++ b/script.js
@@ -140,11 +140,11 @@ function drawNextCard() {
     const card = currentDeck.pop();
     emojiEl.textContent = card.emoji;
     wordEl.textContent = card.word;
-    if (card.word.length > 5) {
-        wordEl.classList.add('small-word');
-    } else {
-        wordEl.classList.remove('small-word');
-    }
+    // Ajuste dinámico del tamaño de fuente para palabras largas
+    const baseSize = 3.2; // tamaño por defecto en rem
+    let fontSize = baseSize - Math.max(0, card.word.length - 5) * 0.3;
+    fontSize = Math.max(fontSize, 1.6); // límite inferior para no hacerlas ilegibles
+    wordEl.style.fontSize = fontSize + 'rem';
     levelEl.textContent = card.level;
 }
 

--- a/style.css
+++ b/style.css
@@ -214,9 +214,6 @@ button:hover {
     text-orientation: upright;
 }
 
-.small-word {
-    font-size: 2.4rem;
-}
 
 #card-display #level {
     font-size: 0.96rem;
@@ -351,6 +348,13 @@ button:hover {
     border: 4px solid var(--color-dark);
     color: var(--color-light);
     text-shadow: 2px 2px 0px rgba(0,0,0,0.2);
+}
+#divider {
+    width: 100%;
+    max-width: 600px;
+    border: none;
+    border-top: 2px dashed rgba(0,0,0,0.2);
+    margin: 20px 0;
 }
 
 #pass-btn {


### PR DESCRIPTION
## Summary
- add divider below cards
- size round input for long words with dynamic scaling
- style divider line

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684af1ef50488327b6c0c3c432d86eb3