### PR TITLE
Improved end of round behaviour

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,7 +53,7 @@ function init() {
 
     fetchWords();
 
-    newGameBtn.addEventListener('click', startGame);
+    newGameBtn.addEventListener('click', prepareGame);
     cardDeck.addEventListener('click', () => {
         if (!gameInProgress) startGame();
     });
@@ -61,6 +61,20 @@ function init() {
     timeInput.addEventListener('change', updateTimeSetting);
     passBtn.addEventListener('click', drawNextCard);
     correctBtn.addEventListener('click', handleCorrect); // <-- CAMBIAR A handleCorrect
+}
+
+function prepareGame() {
+    clearInterval(timer);
+    gameInProgress = false;
+    score = 0;
+    scoreValue.textContent = score;
+    timerDisplay.textContent = '--';
+    const cardArea = document.getElementById('card-area');
+    cardArea.classList.remove('is-flipped');
+    actionButtons.classList.add('hidden');
+    cardDisplay.classList.add('hidden');
+    scoreDisplay.classList.remove('final-score');
+    gameContainer.classList.add('game-active');
 }
 
 // Justo después de la función init(), añade esta nueva función:
@@ -93,6 +107,7 @@ function startGame() {
     score = 0; // <-- Reiniciar puntuación
     scoreValue.textContent = score; // <-- Actualizar display
     gameContainer.classList.add('game-active'); // <-- Mostrar marcador
+    scoreDisplay.classList.remove('final-score');
 
     currentDeck = [...allWords];
     // Fisher-Yates shuffle
@@ -173,5 +188,5 @@ function endGame() {
     cardArea.classList.remove('is-flipped');
     actionButtons.classList.add('hidden');
     timerDisplay.textContent = '--';
-    gameContainer.classList.remove('game-active'); // <-- Ocultar marcador
+    scoreDisplay.classList.add('final-score');
 }

--- a/style.css
+++ b/style.css
@@ -434,6 +434,12 @@ button:hover {
     display: none;
 }
 
+/* Highlight final score with a bright halo */
+.final-score {
+    background: linear-gradient(135deg, #f6d365, #fda085);
+    box-shadow: 0 0 15px 5px rgba(255, 175, 75, 0.7);
+}
+
 /* Clase para activar la animación de pulso */
 .score-pulse {
     animation: scoreUpdate 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);


### PR DESCRIPTION
## Summary
- allow players to start a new round by clicking the deck
- keep score visible when the round ends and highlight the final result

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684af92f02b8832794c431251549824a