### PR TITLE
Add level and tag filter tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,21 @@
         <button id="lang-toggle-btn">Español</button>
     </header>
 
+    <div id="options-tooltip" class="hidden">
+        <h3>Opciones</h3>
+        <div class="level-options">
+            <span>Nivel:</span>
+            <label><input type="radio" name="level-option" value="A1"> A1</label>
+            <label><input type="radio" name="level-option" value="A2"> A2</label>
+            <label><input type="radio" name="level-option" value="both" checked> A1 + A2</label>
+        </div>
+        <div id="tag-options">
+            <span>Tags:</span>
+            <!-- checkboxes added by JS -->
+        </div>
+        <button id="start-game-btn">Start</button>
+    </div>
+
     <main id="game-container">
         <div id="score-display" class="hidden">
             <span id="score-value">0</span>

--- a/script.js
+++ b/script.js
@@ -1,12 +1,14 @@
 // Game State
 let allWords = [];
 let currentDeck = [];
+let selectedLevels = ['A1', 'A2'];
+let selectedTags = [];
 let timer;
 let timeLeft;
 let gameInProgress = false;
 let currentLanguage = 'en';
 let timeSetting = 90;
-let score = 0; // <-- AÑADIR ESTA LÍNEA
+let score = 0;
 
 // Translation Dictionary
 const translations = {
@@ -29,7 +31,8 @@ const translations = {
 // DOM Elements
 let newGameBtn, langToggleBtn, cardDeck, cardDisplay, emojiEl, wordEl, levelEl, timerDisplay, timeInput;
 let actionButtons, passBtn, correctBtn;
-let scoreDisplay, scoreValue, gameContainer; // <-- AÑADIR ESTA LÍNEA
+let scoreDisplay, scoreValue, gameContainer;
+let optionsTooltip, tagOptionsContainer, startGameBtn;
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -47,20 +50,26 @@ function init() {
     actionButtons = document.getElementById('action-buttons');
     passBtn = document.getElementById('pass-btn');
     correctBtn = document.getElementById('correct-btn');
-    scoreDisplay = document.getElementById('score-display'); // <-- AÑADIR ESTA LÍNEA
-    scoreValue = document.getElementById('score-value'); // <-- AÑADIR ESTA LÍNEA
-    gameContainer = document.getElementById('game-container'); // <-- AÑADIR ESTA LÍNEA
+    scoreDisplay = document.getElementById('score-display');
+    scoreValue = document.getElementById('score-value');
+    gameContainer = document.getElementById('game-container');
+    optionsTooltip = document.getElementById('options-tooltip');
+    tagOptionsContainer = document.getElementById('tag-options');
+    startGameBtn = document.getElementById('start-game-btn');
 
     fetchWords();
 
-    newGameBtn.addEventListener('click', prepareGame);
+    newGameBtn.addEventListener('click', () => {
+        optionsTooltip.classList.toggle('hidden');
+    });
     cardDeck.addEventListener('click', () => {
         if (!gameInProgress) startGame();
     });
     langToggleBtn.addEventListener('click', toggleLanguage);
     timeInput.addEventListener('change', updateTimeSetting);
     passBtn.addEventListener('click', drawNextCard);
-    correctBtn.addEventListener('click', handleCorrect); // <-- CAMBIAR A handleCorrect
+    correctBtn.addEventListener('click', handleCorrect);
+    startGameBtn.addEventListener('click', applyOptionsAndStart);
 }
 
 function prepareGame() {
@@ -92,24 +101,66 @@ function handleCorrect() {
 }
 
 function fetchWords() {
-    // Use a relative path so the game works regardless of the hosting folder
     fetch('./words.json')
-        .then(resp => resp.json())
+        .then(resp => resp.text())
+        .then(text => {
+            const lines = text.replace(/\r/g, '').split('\n');
+            const items = [];
+            lines.forEach(line => {
+                const trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith('//') || trimmed === '[' || trimmed === ']') return;
+                const clean = trimmed.replace(/,$/, '');
+                try {
+                    items.push(JSON.parse(clean));
+                } catch (e) {
+                    console.error('Bad line in words.json', line);
+                }
+            });
+            return items;
+        })
         .then(data => {
-            allWords = data.A1 || [];
+            allWords = data;
+            setupOptions();
         })
         .catch(err => console.error('Failed to load words', err));
+}
+
+function setupOptions() {
+    const tags = [...new Set(allWords.map(w => w.tag))];
+    tagOptionsContainer.innerHTML = '';
+    tags.forEach(tag => {
+        const label = document.createElement('label');
+        const chk = document.createElement('input');
+        chk.type = 'checkbox';
+        chk.value = tag;
+        chk.checked = true;
+        label.appendChild(chk);
+        label.append(' ' + tag);
+        tagOptionsContainer.appendChild(label);
+    });
+}
+
+function applyOptionsAndStart() {
+    const levelVal = document.querySelector('input[name="level-option"]:checked').value;
+    selectedLevels = levelVal === 'both' ? ['A1', 'A2'] : [levelVal];
+    selectedTags = Array.from(tagOptionsContainer.querySelectorAll('input[type="checkbox"]:checked')).map(c => c.value);
+    optionsTooltip.classList.add('hidden');
+    prepareGame();
+    startGame();
 }
 
 function startGame() {
     clearInterval(timer);
     gameInProgress = true;
-    score = 0; // <-- Reiniciar puntuación
-    scoreValue.textContent = score; // <-- Actualizar display
-    gameContainer.classList.add('game-active'); // <-- Mostrar marcador
+    score = 0;
+    scoreValue.textContent = score;
+    gameContainer.classList.add('game-active');
     scoreDisplay.classList.remove('final-score');
 
-    currentDeck = [...allWords];
+    currentDeck = allWords.filter(w => selectedLevels.includes(w.level) && (selectedTags.length === 0 || selectedTags.includes(w.tag)));
+    if (currentDeck.length === 0) {
+        currentDeck = [...allWords];
+    }
     // Fisher-Yates shuffle
     for (let i = currentDeck.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));

--- a/style.css
+++ b/style.css
@@ -459,3 +459,25 @@ button:hover {
 #game-container.game-active > #score-display {
     display: block; /* Visible cuando el juego está activo */
 }
+
+/* Tooltip for new game options */
+#options-tooltip {
+    position: absolute;
+    top: 70px;
+    right: 20px;
+    background: var(--color-light);
+    border: 2px solid var(--color-dark);
+    border-radius: 10px;
+    padding: 15px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+    z-index: 100;
+}
+
+#options-tooltip.hidden {
+    display: none;
+}
+
+#options-tooltip label {
+    display: block;
+    margin: 4px 0;
+}


### PR DESCRIPTION
## Summary
- add an options tooltip to pick levels and tags before starting
- parse `words.json` tolerating comments and missing commas
- filter the deck using chosen levels and tags

## Testing
- `node - <<'NODE'
const fs=require('fs');
const text=fs.readFileSync('words.json','utf8');
const lines=text.replace(/\r/g,'').split('\n');
const items=[];
for(const line of lines){
 const t=line.trim();
 if(!t||t.startsWith('//')||t==='['||t===']')continue;
 const c=t.replace(/,$/,'');
 try{items.push(JSON.parse(c));}catch(e){}}
console.log('items',items.length);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_686230366f5c8327aa8768501d6a8843