### PR TITLE
Add topic selection with emoji and English labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,18 +15,19 @@
     </header>
 
     <div id="options-tooltip" class="hidden">
-        <h3>Opciones</h3>
+        <h3 data-lang-key="optionsTitle">Opciones</h3>
         <div class="level-options">
-            <span>Nivel:</span>
+            <span data-lang-key="levelLabel">Nivel:</span>
             <label><input type="radio" name="level-option" value="A1"> A1</label>
             <label><input type="radio" name="level-option" value="A2"> A2</label>
             <label><input type="radio" name="level-option" value="both" checked> A1 + A2</label>
         </div>
         <div id="tag-options">
-            <span>Tags:</span>
+            <span data-lang-key="tagsLabel">Tags:</span>
             <!-- checkboxes added by JS -->
+            <button id="toggle-all-btn" type="button" data-lang-key="selectAll">Todo</button>
         </div>
-        <button id="start-game-btn">Start</button>
+        <button id="start-game-btn" data-lang-key="start">Start</button>
     </div>
 
     <main id="game-container">

--- a/style.css
+++ b/style.css
@@ -137,7 +137,7 @@ button:hover {
     cursor: pointer;
     font-family: var(--font-primary);
     font-size: 2rem;
-    color: var(--color-light);
+    color: #b8860b;
     text-shadow: 2px 2px 5px rgba(0,0,0,0.3);
     position: relative;
     z-index: 1;
@@ -480,4 +480,9 @@ button:hover {
 #options-tooltip label {
     display: block;
     margin: 4px 0;
+}
+
+#toggle-all-btn {
+    margin-top: 8px;
+    width: 100%;
 }


### PR DESCRIPTION
## Summary
- show option menu automatically for the first game
- add emoji labels for categories and translation support
- add toggle button to select all/none of the tags
- translate all option texts
- change "click to start" text color to dark yellow

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68623a3cd37c8327acde653e9abfe2a4