### PR TITLE
Display game options by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <button id="lang-toggle-btn">Español</button>
     </header>
 
-    <div id="options-tooltip" class="hidden">
+    <div id="options-tooltip">
         <h3 data-lang-key="optionsTitle">Opciones</h3>
         <div class="level-options">
             <span data-lang-key="levelLabel">Nivel:</span>

--- a/script.js
+++ b/script.js
@@ -23,8 +23,8 @@ const translations = {
         levelLabel: 'Level:',
         tagsLabel: 'Categories:',
         start: 'Start',
-        selectAll: 'All',
-        selectNone: 'None'
+        selectAll: 'All of them!',
+        selectNone: 'None of them!'
     },
     es: {
         newGame: 'Nueva Partida',


### PR DESCRIPTION
## Summary
- show options panel without needing to click
- update tag toggle wording in English to "All of them!"/"None of them!"

## Testing
- `npm --version`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68623cb6431c83278ca2c5d57f3a8898