### PR TITLE
Tune layout spacing and button styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -97,7 +97,7 @@ button:hover {
     width: var(--card-width);
     height: var(--card-height);
     perspective: 1500px; /* Essential for the 3D flip effect */
-    margin-bottom: 30px;
+    margin-bottom: 15px;
     position: relative; /* Ensure child cards are positioned correctly */
 }
 
@@ -117,7 +117,7 @@ button:hover {
     justify-content: center;
     align-items: center;
     text-align: center;
-    padding: 20px;
+    padding: 15px;
 }
 
 #card-area.is-flipped #card-deck {
@@ -333,7 +333,7 @@ button:hover {
 #action-buttons {
     display: flex;
     gap: 20px;
-    margin-top: 30px;
+    margin-top: 10px;
 }
 
 #action-buttons.hidden {
@@ -342,9 +342,9 @@ button:hover {
 
 #action-buttons button {
     font-family: var(--font-primary);
-    font-size: 1.8rem;
-    padding: 15px 40px;
-    border-radius: 15px;
+    font-size: 1.6rem;
+    padding: 12px 32px;
+    border-radius: 12px;
     border: 4px solid var(--color-dark);
     color: var(--color-light);
     text-shadow: 2px 2px 0px rgba(0,0,0,0.2);
@@ -362,7 +362,7 @@ button:hover {
     max-width: 600px;
     border: none;
     border-top: 2px dashed rgba(0,0,0,0.2);
-    margin: 20px 0;
+    margin: 10px 0;
 }
 
 #pass-btn {


### PR DESCRIPTION
## Summary
- reduce margin below card container and card padding
- tighten spacing above action buttons and shrink them slightly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b917b850c8327b6a607b40268c227