### PR TITLE
Fix default country selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -171,7 +171,7 @@ function setupOptions() {
         const chk = document.createElement('input');
         chk.type = 'checkbox';
         chk.value = tag;
-        chk.checked = selectedTags.length === 0 || selectedTags.includes(tag);
+        chk.checked = (selectedTags.length === 0 && tag !== 'país') || selectedTags.includes(tag);
         label.appendChild(chk);
         label.append(' ' + info.emoji + ' ' + info[currentLanguage]);
         // Insert checkboxes above the toggle button so it stays last


### PR DESCRIPTION
## Summary
- unselect the "país" tag when building options by default

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b9182cd8c8327b63b7ae015059427