### PR TITLE
Move round duration control to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
 
     <header>
         <button id="new-game-btn" data-lang-key="newGame">New Game</button>
+        <div id="controls">
+            <label for="time-input" data-lang-key="timeLabel">Duración de la ronda (s):</label>
+            <input type="number" id="time-input" value="90" min="10">
+        </div>
         <button id="lang-toggle-btn">Español</button>
     </header>
 
@@ -56,10 +60,6 @@
         </div>
         <hr id="divider">
 
-        <div id="controls">
-            <label for="time-input" data-lang-key="timeLabel">Duración de la ronda (s):</label>
-            <input type="number" id="time-input" value="90" min="10">
-        </div>
     </main>
 
     <script src="./script.js"></script>

--- a/style.css
+++ b/style.css
@@ -306,16 +306,18 @@ button:hover {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-top: 30px;
+    margin-top: 0;
     background: rgba(255, 255, 255, 0.5);
     padding: 15px 25px;
     border-radius: 50px;
     box-shadow: 0 4px 15px rgba(0,0,0,0.05);
+    color: #ff6b6b;
 }
 
 #controls label {
     font-weight: 700;
     font-size: 1rem;
+    color: #ff6b6b;
 }
 
 #controls input {


### PR DESCRIPTION
## Summary
- move the time control from the bottom of the page into the header
- color the control text to match the header buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b93e613348327afe7f4803f4aefef