### PR TITLE
Update card layout and level selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,12 @@
         <h3 data-lang-key="optionsTitle">Opciones</h3>
         <div class="level-options">
             <span data-lang-key="levelLabel">Nivel:</span>
-            <label><input type="radio" name="level-option" value="A1"> A1</label>
-            <label><input type="radio" name="level-option" value="A2"> A2</label>
-            <label><input type="radio" name="level-option" value="B1"> B1</label>
-            <label><input type="radio" name="level-option" value="B2"> B2</label>
-            <label><input type="radio" name="level-option" value="C1"> C1</label>
-            <label><input type="radio" name="level-option" value="C2"> C2</label>
-            <label><input type="radio" name="level-option" value="all" checked> A1-C2</label>
+            <label><input type="checkbox" name="level-option" value="A1" checked> A1</label>
+            <label><input type="checkbox" name="level-option" value="A2" checked> A2</label>
+            <label><input type="checkbox" name="level-option" value="B1" checked> B1</label>
+            <label><input type="checkbox" name="level-option" value="B2" checked> B2</label>
+            <label><input type="checkbox" name="level-option" value="C1" checked> C1</label>
+            <label><input type="checkbox" name="level-option" value="C2" checked> C2</label>
         </div>
         <div id="tag-options">
             <span data-lang-key="tagsLabel">Tags:</span>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // Game State
 let allWords = [];
 let currentDeck = [];
-let selectedLevels = ['A1', 'A2'];
+let selectedLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
 let selectedTags = [];
 let timer;
 let timeLeft;
@@ -206,13 +206,11 @@ function setupOptions() {
 }
 
 function applyOptionsAndStart() {
-    const levelVal = document.querySelector('input[name="level-option"]:checked').value;
-    if (levelVal === 'all') {
+    const checkedLevels = Array.from(document.querySelectorAll('input[name="level-option"]:checked')).map(el => el.value);
+    if (checkedLevels.length === 0) {
         selectedLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
-    } else if (levelVal === 'both') {
-        selectedLevels = ['A1', 'A2'];
     } else {
-        selectedLevels = [levelVal];
+        selectedLevels = checkedLevels;
     }
     selectedTags = Array.from(tagOptionsContainer.querySelectorAll('input[type="checkbox"]:checked')).map(c => c.value);
     optionsTooltip.classList.add('hidden');

--- a/style.css
+++ b/style.css
@@ -212,6 +212,7 @@ button:hover {
     text-transform: uppercase;
     writing-mode: vertical-rl;
     text-orientation: upright;
+    direction: rtl;
 }
 
 


### PR DESCRIPTION
## Summary
- allow choosing multiple lexicon levels
- keep vertical text but make wrapped lines appear on the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f87dc136c8327b88e77bdf818c341