### PR TITLE
Add level select-all toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,10 @@
             <h3 data-lang-key="optionsTitle">Options</h3>
 
             <div class="options-section">
-                <span data-lang-key="levelLabel">Level:</span>
+                <div class="options-header">
+                    <span data-lang-key="levelLabel">Level:</span>
+                    <button id="toggle-levels-btn" type="button" data-lang-key="selectAll">All of them!</button>
+                </div>
                 <div class="level-options">
                     <label><input type="checkbox" name="level-option" value="A1"> A1</label>
                     <label><input type="checkbox" name="level-option" value="A2" checked> A2</label>
@@ -63,7 +66,6 @@
                     <label><input type="checkbox" name="level-option" value="B2"> B2</label>
                     <label><input type="checkbox" name="level-option" value="C1"> C1</label>
                     <label><input type="checkbox" name="level-option" value="C2"> C2</label>
-                    <label><input type="checkbox" name="level-option" value="all"> All</label>
                 </div>
             </div>
 

--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ const tagInfo = {
 let newGameBtn, langToggleBtn, cardDeck, cardDisplay, emojiEl, wordEl, levelEl, timerDisplay, timeInput;
 let actionButtons, passBtn, correctBtn;
 let scoreDisplay, scoreValue, gameContainer;
-let optionsModal, tagOptionsContainer, startGameBtn, toggleAllBtn, closeOptionsBtn;
+let optionsModal, tagOptionsContainer, startGameBtn, toggleAllBtn, toggleLevelsBtn, closeOptionsBtn;
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -110,6 +110,7 @@ function init() {
     tagOptionsContainer = document.getElementById('tag-options-container');
     startGameBtn = document.getElementById('start-game-btn');
     toggleAllBtn = document.getElementById('toggle-all-btn');
+    toggleLevelsBtn = document.getElementById('toggle-levels-btn');
     closeOptionsBtn = document.getElementById('close-options-btn');
 
     fetchWords();
@@ -129,6 +130,7 @@ function init() {
     correctBtn.addEventListener('click', handleCorrect);
     startGameBtn.addEventListener('click', applyOptionsAndStart);
     toggleAllBtn.addEventListener('click', toggleSelectAllTags);
+    toggleLevelsBtn.addEventListener('click', toggleSelectAllLevels);
     closeOptionsBtn.addEventListener('click', () => {
         optionsModal.classList.add('hidden');
     });
@@ -204,6 +206,9 @@ function setupOptions() {
         tagOptionsContainer.appendChild(label);
     });
     toggleAllBtn.textContent = translations[currentLanguage].selectAll;
+    toggleAllBtn.setAttribute('data-lang-key', 'selectAll');
+    toggleLevelsBtn.textContent = translations[currentLanguage].selectAll;
+    toggleLevelsBtn.setAttribute('data-lang-key', 'selectAll');
 }
 
 function applyOptionsAndStart() {
@@ -300,7 +305,9 @@ function toggleLanguage() {
     langToggleBtn.textContent = currentLanguage === 'en' ? 'Español' : 'English';
     document.querySelectorAll('[data-lang-key]').forEach(el => {
         const key = el.getAttribute('data-lang-key');
-        el.textContent = translations[currentLanguage][key];
+        if (translations[currentLanguage][key]) {
+            el.textContent = translations[currentLanguage][key];
+        }
     });
     const currentSelections = Array.from(tagOptionsContainer.querySelectorAll('input[type="checkbox"]'))
         .filter(c => c.checked)
@@ -309,6 +316,13 @@ function toggleLanguage() {
         selectedTags = currentSelections;
     }
     setupOptions();
+    // Update toggle buttons to reflect current language and mode
+    toggleAllBtn.textContent = toggleAllBtn.getAttribute('data-lang-key') === 'selectAll'
+        ? translations[currentLanguage].selectAll
+        : translations[currentLanguage].selectNone;
+    toggleLevelsBtn.textContent = toggleLevelsBtn.getAttribute('data-lang-key') === 'selectAll'
+        ? translations[currentLanguage].selectAll
+        : translations[currentLanguage].selectNone;
 }
 
 function toggleSelectAllTags() {
@@ -316,6 +330,20 @@ function toggleSelectAllTags() {
     const selectAll = toggleAllBtn.textContent === translations[currentLanguage].selectAll;
     checkboxes.forEach(c => c.checked = selectAll);
     toggleAllBtn.textContent = selectAll ? translations[currentLanguage].selectNone : translations[currentLanguage].selectAll;
+    toggleAllBtn.setAttribute('data-lang-key', selectAll ? 'selectNone' : 'selectAll');
+}
+
+function toggleSelectAllLevels() {
+    const checkboxes = document.querySelectorAll('.level-options input[type="checkbox"]');
+    const shouldSelectAll = toggleLevelsBtn.getAttribute('data-lang-key') === 'selectAll';
+    checkboxes.forEach(c => c.checked = shouldSelectAll);
+    if (shouldSelectAll) {
+        toggleLevelsBtn.textContent = translations[currentLanguage].selectNone;
+        toggleLevelsBtn.setAttribute('data-lang-key', 'selectNone');
+    } else {
+        toggleLevelsBtn.textContent = translations[currentLanguage].selectAll;
+        toggleLevelsBtn.setAttribute('data-lang-key', 'selectAll');
+    }
 }
 
 function endGame() {

--- a/style.css
+++ b/style.css
@@ -542,6 +542,18 @@ button:hover {
     margin-bottom: 10px;
 }
 
+/* Alignment for level header with toggle button */
+.options-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.options-header > span {
+    margin-bottom: 0;
+}
+
 /* Level & Tag Options */
 .level-options, #tag-options-container {
     display: flex;


### PR DESCRIPTION
## Summary
- add select-all toggle for language levels in options menu
- update styles to align level header with toggle button
- update script to handle level toggle and language translations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fbac7f65083278909137e24f7f603