### PR TITLE
Fix mobile stats layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,12 @@
     </svg>
 
     <header>
-        <button id="new-game-btn" data-lang-key="newGame" class="hidden">New Game</button>
+        <div class="header-buttons">
+            <button id="new-game-btn" data-lang-key="newGame" class="hidden">New Game</button>
+            <button id="lang-toggle-btn">Español</button>
+        </div>
         <h1>Charaditas</h1>
-        <button id="lang-toggle-btn">Español</button>
-    </header>
+      </header>
 
     <div id="options-modal" class="hidden">
         <div id="options-content">
@@ -86,11 +88,12 @@
     </div>
 
     <main id="game-container">
-        <div id="score-display" class="hidden">
-            <span id="score-value">0</span>
+        <div id="stats-container">
+            <div id="score-display" class="hidden">
+                <span id="score-value">0</span>
+            </div>
+            <div id="timer-display">--</div>
         </div>
-
-        <div id="timer-display">--</div>
 
         <div id="card-area">
             <div id="card-deck" class="card" data-lang-key="clickToStart">

--- a/style.css
+++ b/style.css
@@ -75,6 +75,11 @@ header button {
     flex-shrink: 0; /* Prevent buttons from shrinking */
 }
 
+.header-buttons {
+    display: flex;
+    gap: 10px;
+}
+
 #new-game-btn.hidden {
     display: none;
 }
@@ -410,6 +415,69 @@ button:hover {
     #card-display #word { font-size: 2.24rem; }
     #card-display #level { font-size: 0.8rem; top: 10px; right: 10px; }
     #controls { flex-direction: column; padding: 15px; border-radius: 20px; }
+
+    header {
+        flex-direction: column;
+        gap: 10px;
+    }
+    header h1 {
+        font-size: 2.2rem;
+        order: -1;
+    }
+    .header-buttons {
+        display: flex;
+        gap: 15px;
+        width: 100%;
+        justify-content: space-between;
+    }
+    header button {
+        padding: 8px 16px;
+        font-size: 14px;
+    }
+
+    /* CRITICAL STYLES FOR STATS ALIGNMENT */
+    #stats-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+        width: 100%;
+        order: -1;
+    }
+
+    #timer-display {
+        font-size: 3.5rem;
+        text-shadow: 2px 2px 0px var(--color-light);
+    }
+
+    #score-display {
+        font-size: 2rem;
+        padding: 8px 25px;
+        margin-bottom: 0;
+        order: 2;
+    }
+
+    #game-container {
+        gap: 15px;
+    }
+
+    #card-area {
+        margin-bottom: 0;
+    }
+
+    #buttons-divider, #divider {
+        margin: 5px 0;
+    }
+
+    #action-buttons {
+        gap: 15px;
+        margin-top: 0;
+    }
+
+    #action-buttons button {
+        font-size: 1.2rem;
+        padding: 10px 25px;
+    }
 }
 
 
@@ -479,10 +547,10 @@ button:hover {
 }
 
 /* --- También añade esta línea para que el marcador no aparezca hasta que empiece el juego --- */
-#game-container > #score-display {
+#game-container #score-display {
     display: none; /* Oculto por defecto */
 }
-#game-container.game-active > #score-display {
+#game-container.game-active #score-display {
     display: block; /* Visible cuando el juego está activo */
 }
 


### PR DESCRIPTION
## Summary
- move score and timer into a `#stats-container`
- wrap header buttons in `.header-buttons`
- adjust CSS selectors for new DOM
- add responsive styles so timer and score align side-by-side on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fd6efbd6883278e54cf5f64998b36