### PR TITLE
Reduce mobile category button size

### DIFF
--- a/style.css
+++ b/style.css
@@ -482,6 +482,13 @@ button:hover {
         font-size: 1.2rem;
         padding: 10px 25px;
     }
+
+    /* Reduce size of category buttons */
+    .level-options label,
+    #tag-options-container label {
+        font-size: 0.5rem;
+        padding: 4px 6px;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- shrink category buttons when using the mobile layout

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fdec5346c8327ad02d855dafbb063